### PR TITLE
feat(api): PATCH endpoint for partial updates

### DIFF
--- a/SOLUTION.md
+++ b/SOLUTION.md
@@ -1,24 +1,44 @@
-# AVIV technical test solution
-
-You can use this file to write down your assumptions and list the missing features or technical revamp that should
-be achieved with your implementation.
+# AVIV technical test solution BackEnd
 
 ## Notes
 
-Write here notes about your implementation choices and assumptions.
+- noticed PUT was defined but PATCH was not which is more by-the-book method for partial updates, can get messy with sending the full body on each update
+- created the PATCH endpoint with aditional validation for empty payload and invalid fields
+- every change to the latest_price_eur field should create an entry in the price history table
+- I wanted to serve openapi locally with swagger so I adjusted the `listingapi.yaml`, added a PATCH endpoint there and marked PUT as deprecated
+- used existing repository methods to handle database interactions for consisten
 
 ## Questions
 
 This section contains additional questions your expected to answer before the debrief interview.
 
 - **What is missing with your implementation to go to production?**
+- Testing - unit and integration tests
+- Security - auth to restrict access
+- Documentation - openAPI should show some examples and error codes for all endpoints
+- New architecture diagram with Redis for caching and a load balancer for high traffic
 
 - **How would you deploy your implementation?**
 
+- AWS for services like Lambda, ssm params store for storing env secrets
+- GitHub actions for running automation tests (if and when they will exist), build and deployment
+- Leverage CloudWatch for logging and monitoring
+
 - **If you had to implement the same application from scratch, what would you do differently?**
+
+- consider the performance impact of queries on a large dataset early in the design phase
+- probably I would use some lib like Zod for validation to avoid 'doing it by hand'
+- introduce auth from start
+- it would also be good to define test cases before actual implementation
 
 - **The application aims at storing hundreds of thousands listings and millions of prices, and be accessed by millions
   of users every month. What should be anticipated and done to handle it?**
 
+  - high traffic is anticipated, so we should introduce some caching like Redis for frequently accessed data
+  - its expected that endpoints get pinged a lot so some rate limiting should be implemented to avoid huge traffic spikes
+  -
+
   NB: You must update the [given architecture schema](./schemas/Aviv_Technical_Test_Architecture.drawio) by importing it
-  on [diagrams.net](https://app.diagrams.net/) 
+  on [diagrams.net](https://app.diagrams.net/)
+
+

--- a/schemas/listingapi.yaml
+++ b/schemas/listingapi.yaml
@@ -57,16 +57,22 @@ paths:
         name: id
         in: path
         required: true
-        description: The id for the listing to get price history from.
+        description: The ID of the listing to update.
     put:
       summary: Update a listing
       description: Update a listing described by its identifier.
       tags:
         - listings
       operationId: upsert-listing
+      deprecated: true
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ListingWrite"
       responses:
         "200":
-          description: Ok
+          description: OK
           content:
             application/json:
               schema:
@@ -77,11 +83,30 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/APIError"
+    patch:
+      summary: Partially update a listing
+      description: Update specific fields of a listing without replacing the entire resource.
+      tags:
+        - listings
+      operationId: patch-listing
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ListingWrite"
+              $ref: "#/components/schemas/ListingPatch"
+      responses:
+        "200":
+          description: Listing updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Listing"
+        "404":
+          description: Listing not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/APIError"
   "/listings/{id}/prices":
     parameters:
       - schema:
@@ -89,12 +114,13 @@ paths:
         name: id
         in: path
         required: true
-        description: The id for the listing to get price history from.
+        description: The ID of the listing to get price history from.
     get:
       summary: Get listing price history
       description: Get the price history of a listing
       tags:
         - listings
+      operationId: get-listing-prices
       responses:
         "200":
           description: OK
@@ -104,7 +130,6 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/Price"
-      operationId: get-listing-prices
 components:
   schemas:
     Listing:
@@ -113,30 +138,23 @@ components:
         - $ref: "#/components/schemas/ListingWrite"
     ListingRead:
       type: object
-      name: Listing (read only)
       description: Read-only fields of the listing model
       required:
         - id
         - created_date
         - updated_date
-      additionalProperties: false
       properties:
         id:
-          name: Identifier
-          description: The listing unique identifier.
+          description: The unique identifier for the listing.
           type: integer
-          example: 1234
-          minimum: 0
         created_date:
-          name: Creation date
-          description: "The date at which the listing was produced, following RFC 3339."
+          description: The creation date of the listing.
           type: string
-          example: "1970-01-01T00:00:00.000Z"
+          format: date-time
         updated_date:
-          name: Last update date
-          description: "The date at which the listing was last updated, following RFC 3339."
+          description: The last update date of the listing.
           type: string
-          example: "1970-01-01T00:00:00.000Z"
+          format: date-time
     ListingWrite:
       type: object
       required:
@@ -148,85 +166,54 @@ components:
         - surface_area_m2
         - rooms_count
         - bedrooms_count
-      additionalProperties: false
       properties:
         name:
-          name: Name
-          description: A user friendly name for the listing.
           type: string
-          minLength: 1
         postal_address:
           $ref: "#/components/schemas/PostalAddress"
         description:
-          name: Description
-          description: A user friendly description for the listing.
           type: string
-          minLength: 1
         building_type:
-          name: Building type
-          description: The type of building the listing referers to.
           type: string
           enum:
             - STUDIO
             - APARTMENT
             - HOUSE
         latest_price_eur:
-          name: Price
-          description: "The price of the listing, in euros."
           type: number
-          minimum: 0
-          example: 380000
         surface_area_m2:
-          name: Surface area
-          description: "The surface of the listing, in square meters."
           type: number
-          minimum: 0
-          example: 43
         rooms_count:
-          name: Rooms count
-          description: The number of rooms of the listing.
           type: integer
-          minimum: 1
-          example: 2
         bedrooms_count:
-          name: Bedrooms count
-          description: The number of bedrooms of the listing.
           type: integer
-          minimum: 0
-          example: 1
         contact_phone_number:
-          name: Contact phone number
-          description: "Listing main contact phone number, following the E.164 standard."
           type: string
-          pattern: '^\+[1-9]\d{1,14}$'
-    Price:
-      allOf:
-        - $ref: "#/components/schemas/PriceRead"
-        - $ref: "#/components/schemas/PriceWrite"
-    PriceRead:
-      name: Price (read-only)
-      description: Read-only fields for a price.
+    ListingPatch:
       type: object
-      required:
-        - created_date
-      additionalProperties: false
       properties:
-        created_date:
-          name: Creation date
-          description: "The date at which the listing was produced, following RFC 3339."
+        name:
           type: string
-          example: "1970-01-01T00:00:00.000Z"
-    PriceWrite:
-      type: object
-      required:
-        - price_eur
-      additionalProperties: false
-      properties:
-        price_eur:
-          name: Price
-          description: "A price, expressed in euros."
+        postal_address:
+          $ref: "#/components/schemas/PostalAddress"
+        description:
+          type: string
+        building_type:
+          type: string
+          enum:
+            - STUDIO
+            - APARTMENT
+            - HOUSE
+        latest_price_eur:
+          type: number
+        surface_area_m2:
+          type: number
+        rooms_count:
           type: integer
-          example: 340000
+        bedrooms_count:
+          type: integer
+        contact_phone_number:
+          type: string
     PostalAddress:
       type: object
       required:
@@ -234,38 +221,27 @@ components:
         - postal_code
         - city
         - country
-      additionalProperties: false
       properties:
         street_address:
-          name: Street address
           type: string
-          description: The street address of the postal address.
-          example: "48, boulevard des capucins"
-          minLength: 1
         postal_code:
-          name: Postal code
           type: string
-          description: The postal code of the postal address.
-          example: "10294"
-          minLength: 1
         city:
-          name: City
           type: string
-          description: The city of the postal address.
-          example: Paris
-          minLength: 1
         country:
-          name: Country
           type: string
-          description: "The country of the Postal Address, as a ISO 3166-1 alpha-2 country code."
-          example: FR
           minLength: 2
           maxLength: 2
+    Price:
+      type: object
+      properties:
+        price_eur:
+          type: number
+        created_date:
+          type: string
+          format: date-time
     APIError:
       type: object
-      required:
-        - message
-      additionalProperties: false
       properties:
         message:
           type: string

--- a/typescript-serverless/serverless.ts
+++ b/typescript-serverless/serverless.ts
@@ -1,6 +1,11 @@
 import type { AWS } from "@serverless/typescript";
 
-import { addListing, getListings, updateListing } from "@/functions/listing";
+import {
+  addListing,
+  getListings,
+  patchListing,
+  updateListing,
+} from "@/functions/listing";
 import { getListingPrices } from "@/functions/price";
 
 const serverlessConfiguration: AWS = {
@@ -25,7 +30,13 @@ const serverlessConfiguration: AWS = {
   },
   // When adding new functions, you need to restart the watcher
   // to reload the configuration.
-  functions: { getListings, addListing, updateListing, getListingPrices },
+  functions: {
+    getListings,
+    addListing,
+    updateListing,
+    getListingPrices,
+    patchListing,
+  },
   package: { individually: true },
   custom: {
     esbuild: {

--- a/typescript-serverless/src/functions/listing/index.ts
+++ b/typescript-serverless/src/functions/listing/index.ts
@@ -16,3 +16,8 @@ export const updateListing: AWSFunction = {
   handler: `${handlerPath(__dirname)}/handler.updateListing`,
   events: [{ http: buildEventDefinition("put", "/listings/{id}") }],
 };
+
+export const patchListing: AWSFunction = {
+  handler: `${handlerPath(__dirname)}/handler.patchListing`,
+  events: [{ http: buildEventDefinition("patch", "/listings/{id}") }],
+};

--- a/typescript-serverless/src/functions/price/handler.ts
+++ b/typescript-serverless/src/functions/price/handler.ts
@@ -15,13 +15,9 @@ export const getListingPrices = functionHandler<Price[]>(
 
     const priceHistory = await repository.getListingPriceHistory(listingId);
 
-    if (!priceHistory.length) {
-      throw new NotFound(`No price history found for listing ID ${listingId}`);
-    }
-
     return {
       statusCode: 200,
-      response: priceHistory,
+      response: priceHistory || [],
     };
   }
 );


### PR DESCRIPTION
- Added `PATCH /listings/{id}` endpoint for partial updates.
- Implemented validation for empty payloads, returning 400 Bad Request if no fields are provided.
- Added validation to reject invalid or non-existent fields in the payload.
- Updated repository methods to support partial updates and maintain price history tracking.
- Marked the `PUT` endpoint as deprecated in both implementation and OpenAPI spec.
- Updated OpenAPI specification to include the new PATCH endpoint and its schema.